### PR TITLE
Cache fromRegex patterns

### DIFF
--- a/benchmarks/bench.hs
+++ b/benchmarks/bench.hs
@@ -4,10 +4,14 @@ import           Criterion.Main
 import           Data.Aeson     (Value (..))
 import           Expr           (Expr (..))
 import           Fake           (eval, runFakeT)
+import Control.Monad (replicateM)
 
 
 exec :: Expr -> IO Value
 exec expr = runFakeT (Just 1) (eval expr)
+
+execRepeated :: Int -> Expr -> IO [Value]
+execRepeated num expr = runFakeT (Just 1) (replicateM num (eval expr))
 
 
 main :: IO ()
@@ -16,4 +20,5 @@ main = defaultMain
                  , bench "uuid4" $ nfIO (exec "uuid4") ]
   , bgroup "numbers" [ bench "randomInt-0-100"  $ nfIO (exec "randomInt(0, 100)" )
                      , bench "randomInt-0-1000" $ nfIO (exec "randomInt(0, 1000)" ) ]
+  , bgroup "regex" [ bench "from-regex" $ nfIO (execRepeated 20 "fromRegex('[0-1]{10}')") ]
   ]


### PR DESCRIPTION
Without caching:

    benchmarking regex/from-regex
    time                 281.5 μs   (281.2 μs .. 281.8 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 280.1 μs   (279.6 μs .. 281.2 μs)
    std dev              2.518 μs   (1.417 μs .. 4.378 μs)

With:

    benchmarking regex/from-regex
    time                 141.7 μs   (141.5 μs .. 141.9 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 141.8 μs   (141.6 μs .. 142.0 μs)
    std dev              565.6 ns   (475.8 ns .. 676.3 ns)
