### PR TITLE
Add function to join arguments/array into a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ You may also want to read this [introduction and sample use case][1].
  - object(key, value [, ...])
  - fromFile(fileName)
  - fromRegex(pattern)
+ - join(sep, val1, [, ...])
+ - join(array)
 
 
 ## Installation

--- a/src/Aeson.hs
+++ b/src/Aeson.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 
 module Aeson (
   asInt,
@@ -65,7 +66,12 @@ asArray o         = Left $ "Expected an array, but received: " <> show o
 --
 -- >>> asText (Number 10.3)
 -- Right "10.3"
+--
+-- >>> asText (Number 4)
+-- Right "4"
 asText :: Value -> Either String T.Text
 asText (String t) = Right t
-asText (Number n) = Right . T.pack $ show n
+asText (Number n) = Right $ case (S.toBoundedInteger n :: Maybe Int) of
+  Nothing -> T.pack $ show n
+  Just int -> T.pack $ show int
 asText o          = Left $ "Expected a string, but received: " <> show o

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 ---
-resolver: lts-22.13
+resolver: lts-22.29
 
 packages:
   - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 6f0bea3ba5b07360f25bc886e8cff8d847767557a492a6f7f6dcb06e3cc79ee9
-    size: 712905
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/13.yaml
-  original: lts-22.13
+    sha256: 98fe98dae6f42f9b4405e5467f62f57df2896c57b742a09772688c900c722510
+    size: 719579
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/29.yaml
+  original: lts-22.29


### PR DESCRIPTION
Example usage:

    mkjson "x=join('', join(replicate(randomInt(40, 48), randomInt(1, 9))), '.', join(replicate(2, randomInt(1, 9))))"
